### PR TITLE
fix: PHP 8.4 nullable deprecations + modernise CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
-        symfony: [ '7.4', '8.0', '8.1' ]
+        symfony: [ '6.4', '7.4', '8.0', '8.1' ]
         exclude:
           # Symfony 8.x requires PHP >= 8.4
           - php-versions: '8.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '8.1' ]
+        php-versions: [ '8.2' ]
 
     runs-on: ubuntu-latest
     steps:
       # —— Github Checkout 🔎 ——————————————————————————————————————————————————
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -37,18 +37,25 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.4', '8.0', '8.1' ]
-        symfony: [ '5.4', '6.0' ]
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
+        symfony: [ '7.4', '8.0', '8.1' ]
         exclude:
-          - php-versions: '7.4'
-            symfony: '6.0'
+          # Symfony 8.x requires PHP >= 8.4
+          - php-versions: '8.2'
+            symfony: '8.0'
+          - php-versions: '8.3'
+            symfony: '8.0'
+          - php-versions: '8.2'
+            symfony: '8.1'
+          - php-versions: '8.3'
+            symfony: '8.1'
 
     runs-on: ${{ matrix.operating-system }}
 
     steps:
         # —— Git Checkout PR branch ——————————————————————————————————————————
       - name: Git Checkout PR branch (${{ github.ref }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -65,13 +72,13 @@ jobs:
       # —— Composer cache ————————————————————————————————————————————————————
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ matrix.symfony }}
           restore-keys: ${{ runner.os }}-composer-
 
       # —— Install composer dependencies —————————————————————————————————————
@@ -79,9 +86,10 @@ jobs:
         env:
           COMPOSER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          composer global require --no-interaction --no-progress symfony/flex:^1.11
+          composer global config --no-plugins allow-plugins.symfony/flex true
+          composer global require --no-interaction --no-progress symfony/flex
           composer config extra.symfony.require "${{ matrix.symfony }}.*"
-          composer install --no-progress --no-scripts -q
+          composer update --no-progress --no-scripts
 
 #      # —— PHPStan  ——————————————————————————————————————————————————————————
 #      - name: PHPStan (PHP Static Analysis)

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     "php": "^8.2",
     "ext-json": "*",
     "phpdocumentor/reflection-docblock": "^5.3",
-    "symfony/debug-bundle": "^6.4|^7.0|^8.0",
-    "symfony/http-client": "^6.4|^7.0|^8.0",
-    "symfony/property-access": "^6.4|^7.0|^8.0",
-    "symfony/property-info": "^6.4|^7.0|^8.0",
-    "symfony/serializer": "^6.4|^7.0|^8.0"
+    "symfony/debug-bundle": "^6.4|^7.4|^8.0",
+    "symfony/http-client": "^6.4|^7.4|^8.0",
+    "symfony/property-access": "^6.4|^7.4|^8.0",
+    "symfony/property-info": "^6.4|^7.4|^8.0",
+    "symfony/serializer": "^6.4|^7.4|^8.0"
   },
   "require-dev" : {
     "friendsofphp/php-cs-fixer": "^3.15",
     "phpstan/phpstan": "^1.8.7",
     "phpunit/phpunit": "^9.5|^10.0",
-    "symfony/var-dumper": "^6.4|^7.0|^8.0"
+    "symfony/var-dumper": "^6.4|^7.4|^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,17 +14,17 @@
     "php": "^8.2",
     "ext-json": "*",
     "phpdocumentor/reflection-docblock": "^5.3",
-    "symfony/debug-bundle": "^6.4|^7.0",
-    "symfony/http-client": "^6.4|^7.0",
-    "symfony/property-access": "^6.4|^7.0",
-    "symfony/property-info": "^6.4|^7.0",
-    "symfony/serializer": "^6.4|^7.0"
+    "symfony/debug-bundle": "^6.4|^7.0|^8.0",
+    "symfony/http-client": "^6.4|^7.0|^8.0",
+    "symfony/property-access": "^6.4|^7.0|^8.0",
+    "symfony/property-info": "^6.4|^7.0|^8.0",
+    "symfony/serializer": "^6.4|^7.0|^8.0"
   },
   "require-dev" : {
     "friendsofphp/php-cs-fixer": "^3.15",
     "phpstan/phpstan": "^1.8.7",
     "phpunit/phpunit": "^9.5|^10.0",
-    "symfony/var-dumper": "^6.4|^7.0"
+    "symfony/var-dumper": "^6.4|^7.0|^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -24,7 +24,7 @@ final class Connection
 
     private ?HttpClientInterface $client = null;
 
-    public function __construct(string $uri = null)
+    public function __construct(?string $uri = null)
     {
         if ($uri) {
             $this->uri = $uri;

--- a/src/Serializer/Normalizer/ArrivalNormalizer.php
+++ b/src/Serializer/Normalizer/ArrivalNormalizer.php
@@ -14,12 +14,12 @@ final class ArrivalNormalizer implements DenormalizerInterface
      *
      * @throws \Exception
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): \DateTimeImmutable
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): \DateTimeImmutable
     {
         return DateTimeUtil::fromUTC(new \DateTimeImmutable('@'.$data));
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return 'DateTimeImmutable' === $type && is_int($data) && $data > 604800;
     }

--- a/src/Serializer/Normalizer/LocationNormalizer.php
+++ b/src/Serializer/Normalizer/LocationNormalizer.php
@@ -13,7 +13,7 @@ final class LocationNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @param Location $object
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         return [
             $object->lon,
@@ -24,7 +24,7 @@ final class LocationNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @param Location $data
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Location;
     }
@@ -32,7 +32,7 @@ final class LocationNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @param array $data
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Location
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Location
     {
         return new Location($data[0], $data[1]);
     }
@@ -40,7 +40,7 @@ final class LocationNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * @param array $data
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return Location::class === $type;
     }

--- a/src/Serializer/Normalizer/TimeWindowNormalizer.php
+++ b/src/Serializer/Normalizer/TimeWindowNormalizer.php
@@ -15,7 +15,7 @@ final class TimeWindowNormalizer implements NormalizerInterface
     /**
      * @param TimeWindowInterface $object
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): ?array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): ?array
     {
         if ($object instanceof AbsoluteTimeWindow) {
             return [
@@ -37,7 +37,7 @@ final class TimeWindowNormalizer implements NormalizerInterface
     /**
      * @param TimeWindowInterface $data
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof TimeWindowInterface;
     }


### PR DESCRIPTION
Targets the `v3.0` branch.

## 1. Explicit nullable types (PHP 8.4 deprecations)

PHP 8.4 deprecates *implicitly nullable* parameters (a typed parameter whose default is `null`). Made explicit with `?type`:

> `Implicitly marking parameter $x as nullable is deprecated, the explicit nullable type must be used instead`

| File | Parameters |
|---|---|
| `src/Serializer/Normalizer/TimeWindowNormalizer.php` | `$format` ×2 |
| `src/Serializer/Normalizer/LocationNormalizer.php` | `$format` ×4 |
| `src/Serializer/Normalizer/ArrivalNormalizer.php` | `$format` ×2 |
| `src/Connection.php` | `$uri` (constructor) |

The 8 normalizer locations are the ones surfaced in MKO-1330; `Connection::__construct` had the same pattern and is fixed too. No behavioural change.

## 2. Supported-version policy + CI matrix

Supported Symfony lines are now **LTS + current only**:

```
^6.4 (LTS) | ^7.4 (LTS) | ^8.0 (current)
```

- Added Symfony 8 (`|^8.0`)
- Dropped EOL Symfony 7.0–7.3 (narrowed `^7.0` → `^7.4`)

CI matrix replaced (was PHP 7.4–8.1 × Symfony 5.4/6.0, none supported) and now exercises the full declared range:

| Symfony | PHP |
|---|---|
| 6.4 | 8.2, 8.3, 8.4, 8.5 |
| 7.4 | 8.2, 8.3, 8.4, 8.5 |
| 8.0 | 8.4, 8.5 |
| 8.1 | 8.4, 8.5 |

(Symfony 8.x requires PHP ≥ 8.4.)

Supporting CI changes: php-cs-fixer job 8.1 → 8.2; `actions/checkout@v2`→`@v4`, `actions/cache@v2`→`@v4`; removed `::set-output` → `$GITHUB_OUTPUT`; activate `symfony/flex` and use `composer update` (no lock committed).

## Semver note

Narrowing `^7.0` → `^7.4` drops (EOL) 7.1–7.3, so this is **not purely additive** — suggest releasing as a **minor (3.1.0)** rather than a 3.0.1 patch.

## Verification (local, PHP 8.5)

- phpunit: **3/3 pass** on Symfony **6.4.37**, **7.4.10** and **8.1.0**, no PHP implicit-nullable deprecations
- phpstan: no errors · php-cs-fixer `--dry-run`: 0 files · `php -l`: clean · `composer validate`: valid

Ref: MKO-1330