### PR TITLE
chore: modernise dev tooling (Rector, PHPStan 2, PHPUnit 11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,15 @@ jobs:
           composer config extra.symfony.require "${{ matrix.symfony }}.*"
           composer update --no-progress --no-scripts
 
-#      # —— PHPStan  ——————————————————————————————————————————————————————————
-#      - name: PHPStan (PHP Static Analysis)
-#        run: php vendor/phpstan/phpstan/phpstan.phar --memory-limit=1G
-
       # —— Run tests —————————————————————————————————————————————————————————
       - name: Run Tests
         run: php vendor/bin/phpunit
+
+      # —— PHPStan ———————————————————————————————————————————————————————————
+      # Run per Symfony/PHP combination so version-specific type issues surface.
+      - name: PHPStan (static analysis)
+        run: php vendor/bin/phpstan analyse --no-progress
+
+      # —— Rector ————————————————————————————————————————————————————————————
+      - name: Rector (dry-run)
+        run: php vendor/bin/rector process --dry-run --no-progress-bar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
         run: php vendor/bin/phpunit
 
       # —— PHPStan ———————————————————————————————————————————————————————————
-      # Run per Symfony/PHP combination so version-specific type issues surface.
       - name: PHPStan (static analysis)
         run: php vendor/bin/phpstan analyse --no-progress
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # —— Github Checkout 🔎 ——————————————————————————————————————————————————
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
     steps:
         # —— Git Checkout PR branch ——————————————————————————————————————————
       - name: Git Checkout PR branch (${{ github.ref }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ matrix.symfony }}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "phpdocumentor/reflection-docblock": "^5.3",
     "symfony/debug-bundle": "^6.4|^7.4|^8.0",
     "symfony/http-client": "^6.4|^7.4|^8.0",
     "symfony/property-access": "^6.4|^7.4|^8.0",
@@ -23,7 +22,7 @@
   "require-dev" : {
     "friendsofphp/php-cs-fixer": "^3.15",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^11.0",
+    "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
     "rector/rector": "^2.0",
     "symfony/var-dumper": "^6.4|^7.4|^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require-dev" : {
     "friendsofphp/php-cs-fixer": "^3.15",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+    "phpunit/phpunit": "^11.0|^12.0|^13.0",
     "rector/rector": "^2.0",
     "symfony/var-dumper": "^6.4|^7.4|^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,9 @@
   },
   "require-dev" : {
     "friendsofphp/php-cs-fixer": "^3.15",
-    "phpstan/phpstan": "^1.8.7",
-    "phpunit/phpunit": "^9.5|^10.0",
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "^11.0",
+    "rector/rector": "^2.0",
     "symfony/var-dumper": "^6.4|^7.4|^8.0"
   },
   "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,9 @@ parameters:
 	paths:
 		- src
 		- tests
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
+	ignoreErrors:
+		# PHPStan 2.0 removed the `checkMissingIterableValueType` and
+		# `checkGenericClassInNonGenericObjectType` parameters; keep the
+		# project's original opt-out by ignoring the equivalent identifiers.
+		- identifier: missingType.iterableValue
+		- identifier: missingType.generics

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,6 @@ parameters:
 		- src
 		- tests
 	ignoreErrors:
-		# PHPStan 2.0 removed the `checkMissingIterableValueType` and
-		# `checkGenericClassInNonGenericObjectType` parameters; keep the
-		# project's original opt-out by ignoring the equivalent identifiers.
+		# PHPStan 2.0 removed the `checkMissingIterableValueType` parameter;
+		# keep the project's original opt-out via the equivalent identifier.
 		- identifier: missingType.iterableValue
-		- identifier: missingType.generics

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Test Suite for vroom-php">
       <directory>./tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory>./src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Test Suite for vroom-php">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    // Target the lowest supported PHP version so generated code stays
+    // compatible with every consumer (composer.json requires php ^8.2).
+    ->withPhpSets(php82: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        earlyReturn: true,
+    );

--- a/src/Resource/AbsoluteTimeWindow.php
+++ b/src/Resource/AbsoluteTimeWindow.php
@@ -6,13 +6,7 @@ namespace Webstack\Vroom\Resource;
 
 final class AbsoluteTimeWindow implements TimeWindowInterface
 {
-    public \DateTimeImmutable $start;
-
-    public \DateTimeImmutable $end;
-
-    public function __construct(\DateTimeImmutable $start, \DateTimeImmutable $end)
+    public function __construct(public \DateTimeImmutable $start, public \DateTimeImmutable $end)
     {
-        $this->start = $start;
-        $this->end = $end;
     }
 }

--- a/src/Resource/RelativeTimeWindow.php
+++ b/src/Resource/RelativeTimeWindow.php
@@ -6,13 +6,7 @@ namespace Webstack\Vroom\Resource;
 
 final class RelativeTimeWindow implements TimeWindowInterface
 {
-    public int $start;
-
-    public int $end;
-
-    public function __construct(int $start, int $end)
+    public function __construct(public int $start, public int $end)
     {
-        $this->start = $start;
-        $this->end = $end;
     }
 }

--- a/src/Resource/ShipmentStep.php
+++ b/src/Resource/ShipmentStep.php
@@ -6,8 +6,6 @@ namespace Webstack\Vroom\Resource;
 
 class ShipmentStep
 {
-    public int $id;
-
     public string $description;
 
     public Location $location;
@@ -23,8 +21,7 @@ class ShipmentStep
      */
     public array $timeWindows;
 
-    public function __construct(int $id)
+    public function __construct(public int $id)
     {
-        $this->id = $id;
     }
 }

--- a/src/Resource/Vehicle.php
+++ b/src/Resource/Vehicle.php
@@ -9,8 +9,6 @@ namespace Webstack\Vroom\Resource;
  */
 final class Vehicle
 {
-    public int $id;
-
     public string $profile;
 
     public string $description;
@@ -52,8 +50,7 @@ final class Vehicle
 
     public array $steps;
 
-    public function __construct(int $id)
+    public function __construct(public int $id)
     {
-        $this->id = $id;
     }
 }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -34,6 +34,8 @@ final class Serializer extends BaseSerializer
     }
 
     /**
+     * @return \ArrayObject<array-key, mixed>|array|string|int|float|bool|null
+     *
      * @throws SerializerExceptionInterface
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): \ArrayObject|array|string|int|float|bool|null

--- a/src/Serializer/Normalizer/LocationNormalizer.php
+++ b/src/Serializer/Normalizer/LocationNormalizer.php
@@ -21,9 +21,6 @@ final class LocationNormalizer implements NormalizerInterface, DenormalizerInter
         ];
     }
 
-    /**
-     * @param Location $data
-     */
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof Location;

--- a/src/Serializer/Normalizer/TimeWindowNormalizer.php
+++ b/src/Serializer/Normalizer/TimeWindowNormalizer.php
@@ -34,9 +34,6 @@ final class TimeWindowNormalizer implements NormalizerInterface
         return null;
     }
 
-    /**
-     * @param TimeWindowInterface $data
-     */
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof TimeWindowInterface;

--- a/src/Util/DateTimeUtil.php
+++ b/src/Util/DateTimeUtil.php
@@ -13,9 +13,8 @@ final class DateTimeUtil
 
         $localDateTime = new \DateTimeImmutable();
         $localDateTime = $localDateTime->setDate((int) $dateTime->format('Y'), (int) $dateTime->format('m'), (int) $dateTime->format('d'));
-        $localDateTime = $localDateTime->seTTime((int) $dateTime->format('H'), (int) $dateTime->format('i'), (int) $dateTime->format('s'));
 
-        return $localDateTime;
+        return $localDateTime->seTTime((int) $dateTime->format('H'), (int) $dateTime->format('i'), (int) $dateTime->format('s'));
     }
 
     public static function toUTC(\DateTimeImmutable $dateTime): \DateTimeImmutable
@@ -23,8 +22,7 @@ final class DateTimeUtil
         $localDateTime = new \DateTimeImmutable();
         $localDateTime = $localDateTime->setTimezone(new \DateTimeZone('UTC'));
         $localDateTime = $localDateTime->setDate((int) $dateTime->format('Y'), (int) $dateTime->format('m'), (int) $dateTime->format('d'));
-        $localDateTime = $localDateTime->seTTime((int) $dateTime->format('H'), (int) $dateTime->format('i'), (int) $dateTime->format('s'));
 
-        return $localDateTime;
+        return $localDateTime->seTTime((int) $dateTime->format('H'), (int) $dateTime->format('i'), (int) $dateTime->format('s'));
     }
 }


### PR DESCRIPTION
**Stacked on #9** (base is that branch, so this diff shows only the modernisation; GitHub will retarget to `v3.0` once #9 merges).

Dev-only modernisation — **runtime support is unchanged**: Symfony floor stays `^6.4` (LTS), PHP stays `^8.2`.

## Tooling

- **Rector 2.x** added with `rector.php` targeting **PHP 8.2** (the lowest supported version, so generated code never emits syntax that breaks 8.2 consumers). Sets: php82 + dead-code, code-quality, type-declaration, early-return.
- **PHPStan `^1.8.7` → `^2.1`**. The 2.0-removed `checkMissingIterableValueType` param is replaced by the equivalent `ignoreErrors` identifier `missingType.iterableValue` (level 9 kept).
- **PHPUnit `^9.5|^10.0` → `^11.0 || ^12.0 || ^13.0`**. PHPUnit 13 needs PHP 8.4+, 12 needs 8.3, 11 needs 8.2 — the range lets each matrix PHP version install a compatible major (8.2→11, 8.3→12, 8.4/8.5→13) while keeping the `^8.2` floor. Migrated `phpunit.xml.dist` to the 13.2 schema (verified it still loads on PHPUnit 11). Tests pass unchanged (`OK (3 tests, 7 assertions)`).

## Dependency cleanup

- **Removed `phpdocumentor/reflection-docblock`** — it was unused. The serializer wires `ReflectionExtractor` (reads native PHP type declarations), never `PhpDocExtractor` (the only consumer of reflection-docblock); no test references it and nothing else requires it. Symfony 8 even *conflicts* with reflection-docblock `>=7`, so it couldn't be bumped regardless. Tests/serialisation stay green without it.

## Code changes (no behavioural change)

Applied by Rector (all PHP 8.2-valid):
- Constructor property promotion: `AbsoluteTimeWindow`, `RelativeTimeWindow`, `ShipmentStep`, `Vehicle`
- Dropped a useless intermediate variable in `DateTimeUtil` (×2)
- Removed incorrect `@param` phpdocs on the `supports*()` normalizer methods — those receive `mixed`, and the wrong docblocks made PHPStan flag the `instanceof` checks as always-true

Manual PHPStan fixes:
- `Serializer::normalize()` — added `@return \ArrayObject<array-key, mixed>|...` so the generic `\ArrayObject` return type is complete. PHPStan flagged `missingType.generics` only on Symfony 6.4/7.4/8.0 (8.1's parent signature suppressed it); specifying the generics at the source keeps it green on every version (a plain ignore would go unmatched on the 8.1 jobs).

## CI

- **PHPStan + Rector (dry-run) run inside the Symfony matrix**, so static analysis is exercised against every Symfony/PHP combination
- Removed the dead commented-out PHPStan block (stale `.phar` path)

## Verification

- ✅ Full CI matrix green (12 Symfony/PHP combos + php-cs-fixer)
- Local (PHP 8.5): phpunit **3/3** (PHPUnit 13) · phpstan **no errors** on Symfony 6.4/7.4/8.1 · rector **clean** · php-cs-fixer **0 files** · composer validate **valid**