### PR TITLE
Support VROOM 1.15 task and cost properties

### DIFF
--- a/src/Resource/Costs.php
+++ b/src/Resource/Costs.php
@@ -9,4 +9,8 @@ class Costs
     public int $fixed = 0;
 
     public int $perHour = 3600;
+
+    public int $perTaskHour = 0;
+
+    public int $perKm = 0;
 }

--- a/src/Resource/ShipmentStep.php
+++ b/src/Resource/ShipmentStep.php
@@ -17,6 +17,16 @@ class ShipmentStep
     public int $service;
 
     /**
+     * @var array<string, int>
+     */
+    public array $setupPerType;
+
+    /**
+     * @var array<string, int>
+     */
+    public array $servicePerType;
+
+    /**
      * @var array<TimeWindowInterface>
      */
     public array $timeWindows;

--- a/src/Resource/Vehicle.php
+++ b/src/Resource/Vehicle.php
@@ -33,6 +33,8 @@ final class Vehicle
      */
     public array $skills;
 
+    public string $type;
+
     public TimeWindowInterface $timeWindow;
 
     /**

--- a/src/Resource/VehicleStep.php
+++ b/src/Resource/VehicleStep.php
@@ -6,7 +6,7 @@ namespace Webstack\Vroom\Resource;
 
 class VehicleStep
 {
-    public string $key;
+    public string $type;
 
     public int $id;
 

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -7,6 +7,8 @@ namespace Webstack\Vroom\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\ExceptionInterface as SerializerException;
 use Webstack\Vroom\Resource\AbsoluteTimeWindow;
+use Webstack\Vroom\Resource\Costs;
+use Webstack\Vroom\Resource\Job;
 use Webstack\Vroom\Resource\Location;
 use Webstack\Vroom\Resource\RelativeTimeWindow;
 use Webstack\Vroom\Resource\Vehicle;
@@ -70,5 +72,44 @@ final class SerializerTest extends TestCase
             0,
             14400,
         ], $this->serializer->normalize($relativeTimeWindow));
+    }
+
+    /**
+     * @throws SerializerException
+     */
+    public function testNormalizeVehicleTypeAndCosts(): void
+    {
+        $vehicle = new Vehicle(1);
+        $vehicle->type = 'truck';
+        $vehicle->costs = new Costs();
+        $vehicle->costs->perTaskHour = 1800;
+        $vehicle->costs->perKm = 100;
+
+        $this->assertEquals([
+            'id' => 1,
+            'costs' => [
+                'fixed' => 0,
+                'per_hour' => 3600,
+                'per_task_hour' => 1800,
+                'per_km' => 100,
+            ],
+            'type' => 'truck',
+        ], $this->serializer->normalize($vehicle));
+    }
+
+    /**
+     * @throws SerializerException
+     */
+    public function testNormalizeJobPerType(): void
+    {
+        $job = new Job(999);
+        $job->setupPerType = ['truck' => 120, 'bike' => 300];
+        $job->servicePerType = ['truck' => 60];
+
+        $this->assertEquals([
+            'id' => 999,
+            'setup_per_type' => ['truck' => 120, 'bike' => 300],
+            'service_per_type' => ['truck' => 60],
+        ], $this->serializer->normalize($job));
     }
 }


### PR DESCRIPTION
## What

Adds the new input properties introduced in [VROOM 1.15.0](https://github.com/VROOM-Project/vroom/blob/master/CHANGELOG.md) so the client can model the latest API:

| API field | Resource | PHP property |
| --- | --- | --- |
| `setup_per_type` | job / shipment_step | `ShipmentStep::$setupPerType` |
| `service_per_type` | job / shipment_step | `ShipmentStep::$servicePerType` |
| `type` | vehicle | `Vehicle::$type` |
| `per_task_hour` | cost | `Costs::$perTaskHour` |

These cover the three 1.15 features: per-vehicle-type task times (#336) and task-time costs (#1130). `Job` inherits the per-type fields via `ShipmentStep`.

Also includes two fixes found while auditing the resources against the full API spec:

- **`Costs::$perKm`** — `per_km` (cost object, added in VROOM 1.14) was missing entirely.
- **`VehicleStep` `key` → `type`** — the custom-route step field was serialized as `key`, but VROOM expects `type` (`start`/`job`/`pickup`/`delivery`/`break`/`end`), so custom routes / plan mode could not work.

## Why

Keeps the OO client in sync with the VROOM 1.15 API and fixes a serialization bug that broke `vehicle.steps`.

## Verification

- Added serializer tests for the new vehicle `type`, cost fields and per-type task durations.
- Full audit confirms all 1.15 properties are present and no bogus fields remain.
- `phpstan` clean, `phpunit` green (5 tests).